### PR TITLE
feat: ClaimHelper periphery for multi-pass reward claims

### DIFF
--- a/docs/staking-claim-cap-fix.md
+++ b/docs/staking-claim-cap-fix.md
@@ -1,0 +1,195 @@
+# Staking "no rewards" tickets: root cause, fix options & estimates
+
+> Tech doc requested by Nacho. Context: recurring support tickets ("staked but no rewards") —
+> three verified cases June 2026, one earlier case March 2026, all the same cause.
+> On-chain debugging playbook: `.claude/skills/staking-support-debug/` in this repo.
+
+## Root cause (verified on-chain, not a bug)
+
+`StakingRewardDistributor.claim()` processes at most **52 weeks per call**
+(`MAX_REWARD_ITERATIONS`, `StakingRewardDistributor.sol:74`) from the user's stored
+`weekCursorOf`, then saves the cursor and stops. Users whose last claim is >52 weeks old
+(typical: claimed once on a small 2024 lock, later converted/topped-up in 2026) get a claim
+that walks 52 old zero-balance weeks, **pays 0, and the portal hides the Claim button**.
+
+The portal makes it worse in two specific places (`apps/portal`, walletconnect-apps):
+
+- `stake/_components/cards/rewards-card.tsx:34` — `actions={claimSimulation.data ? <Actions/> : null}`:
+  `0n` is falsy ⇒ no button rendered at all.
+- `ClaimButton`/`ClaimRewardsDrawer` — `isDisabled={!amount}` and `if (!amount) return` ⇒ even if
+  rendered, a 0-preview claim can't be sent. The user is hard-locked out of the very action
+  (claim repeatedly) that fixes their state.
+
+Verified examples: pending 37.50 / 110.94 / 9.63 WCT behind a 0-showing button; 2 claim passes each.
+
+## How PancakeSwap (our upstream fork source) solved it
+
+Their `RevenueSharingPool.claim()`/`claimForUser()` is **permissionless** — anyone can trigger a
+claim *for* a user; payout destination is unchanged so there's nothing to steal. On top they run a
+24-line periphery, `RevenueSharingPoolGateway` (BSC `0x011f2a82846a4E9c62C2FC4Fd6fDbad19147D94A`):
+
+```solidity
+function claimMultipleWithoutProxy(address[] calldata pools, address _for) external {
+    for (uint256 i = 0; i < pools.length; i++) {
+        IRevenueSharingPool(pools[i]).claimForUser(_for);
+    }
+}
+```
+
+One transaction, multiple inner claims; state persists within the tx, so each inner call advances
+the cursor another 52 weeks. A 78-week backlog clears in one click, no simulation gymnastics.
+Our fork closed this door by adding the `UnauthorizedClaimer` check
+(`StakingRewardDistributor.sol:489-491`): only the user or their recipient may call `claim(user)`.
+Since we don't upgrade deployed contracts outside security fixes, parity via `claimForUser` is not
+on the table — but the **recipient hook the fork kept** enables an equivalent periphery (Tier 2b),
+and account-level batching (Tier 2a) needs no contract at all.
+
+## Existing infrastructure we can leverage
+
+- **Indexer**: `reown-com/onchain-api` (Ponder) already ingests `StakeWeight` Deposit/Withdraw/
+  PermanentConversion and **SRD `RewardsClaimed`** → Postgres tables `lock` and `reward`.
+  Today the `RewardsClaimed` handler keeps only a cumulative sum and discards `claimEpoch`,
+  `maxEpoch`, block timestamp, and tx hash.
+- **API**: `services/foundation-api` (walletconnect-apps, Hono on Cloudflare Workers) serves
+  `/staking?address=` from those tables, already fronted by a token-bucket rate limiter
+  (durable object) — the natural place for a cheap per-user flag.
+- **Portal**: `weekCursorOf` is already in the generated ABI; `position.createdAt` already
+  fetched; dashboard app already has EIP-5792 plumbing (`sendCalls`, `waitForBatchedTx`).
+- **Semantics bug feeding the tickets**: portal's "All time rewards" renders `reward.amount`,
+  which is all-time **claimed**, not earned. Affected users see "All time rewards: 0.196 WCT"
+  next to "Rewards: 0" — the UI corroborates their "I got nothing" belief. Relabel ("Claimed so
+  far") or add an earned figure.
+
+## Fix options
+
+### Tier 0 — docs + support guide (ship today, no code)
+
+User-facing page: "Why does my claim show 0?" with the Etherscan write-proxy walkthrough
+(`claimTo` / `claim(yourAddress)` 2–3× at the SRD proxy). Helena links it; support stops
+escalating. Effort: **hours**.
+
+### Tier 1 — portal: detect the gap, unlock the button, guide the passes (~2–3 days)
+
+No backend, no contract change, ~zero marginal RPC.
+
+**Detection** (new `useOlderRewards()` hook):
+
+```ts
+const WEEK = 604_800n;
+// one extra read, batched by viem into the existing multicall — zero extra HTTP requests
+const weekCursor = read SRD.weekCursorOf(address);
+const currentWeek = BigInt(Math.floor(Date.now() / 1000 / 604_800)) * WEEK; // client math
+// never-claimed users have weekCursor == 0: fall back to position.createdAt (already fetched)
+const anchor = weekCursor > 0n ? weekCursor
+             : BigInt(Math.floor(stakingInfo.position.createdAt.getTime() / 1000 / 604_800)) * WEEK;
+const weeksBehind = (currentWeek - anchor) / WEEK;
+const hasOlderRewards = weeksBehind > 52n;          // the flag — no exact amount needed
+const passesNeeded = Number((weeksBehind + 51n) / 52n);
+```
+
+`weekCursorOf` only changes when the user claims ⇒ react-query cache + invalidate in the claim
+mutation's `onSuccess` (alongside the existing invalidations).
+
+**Display — three states for `RewardsCard`:**
+
+| State | Condition | Card shows | Action |
+|---|---|---|---|
+| Normal | no gap | amount (as today) | Claim (as today) |
+| Backlog, hidden rewards | gap && preview == 0 | badge **"Older rewards available"** instead of bare 0 | button **enabled**: "Claim older rewards" |
+| Backlog, partial preview | gap && preview > 0 | amount + caption *"more available after this claim"* | guided claim |
+
+Copy for the drawer in backlog mode (no jargon, no exact numbers needed):
+
+> Your rewards history is longer than one claim can process. Claiming takes N quick
+> transactions. The first one(s) may show 0 WCT — that's expected: they unlock your
+> remaining rewards. We'll guide you through each step.
+
+**Guided flow:** turn `ClaimRewardsDrawer` into a stepper ("Claim — pass 1 of N"). The mutation
+loops: `claimTo` → wait receipt → re-read `weekCursorOf` → next pass while `weeksBehind > 52`,
+final pass shows the real amount in the success toast. Each pass is an O(cents) OP tx with ~2s
+confirmation. Required fixes regardless: `rewards-card.tsx:34` falsy-`0n` render guard and the
+`!amount` disables must also branch on `hasOlderRewards`.
+
+**Optional polish (+1 day):** wagmi `useSendCalls` (EIP-5792) to batch all passes into one wallet
+confirmation where the wallet supports atomic batch (`wallet_getCapabilities`); sequential
+fallback otherwise. Good story for WalletConnect to dogfood 5792.
+
+False-positive note: a gapped wallet with no active position and nothing pending would be told to
+claim for nothing. Gate the badge on `stakingInfo.position` existing (covers ~all real cases); the
+Tier 1b backend flag makes it exact.
+
+### Tier 1b — detection lives at the indexer (RECOMMENDED shape, ~2–3 days total)
+
+Zero portal RPC; the detection data materializes where the events already flow, and Ponder's
+re-sync model gives backfill for free:
+
+1. **onchain-api (Ponder)** — in the `RewardsClaimed` handler, also read the exact
+   `weekCursorOf(user)` via `context.client.readContract` at the event block (one cached read per
+   claim event — not per page view) and store `weekCursor` + `lastClaimAt` on the `reward` row.
+   Add a `rewardClaim` history table (address, amount, claimEpoch, maxEpoch, txHash, timestamp)
+   alongside the cumulative sum — support gets full claim history in our own Postgres (today we
+   fetch it from Blockscout), and "All time rewards" can be relabeled honestly ("Claimed so far").
+   **Backfill is automatic**: a Ponder schema/handler change triggers a full re-sync, so every
+   historical claim flows through the new handler and `weekCursor` materializes for all past
+   claimers. (Caveat: historical `readContract` needs archive state from the configured RPC.)
+   **Store the cursor, not the flag** — `hasOlderRewards` is time-dependent (becomes true as weeks
+   pass with no events) and would rot if persisted; the static cursor is the durable fact.
+2. **foundation-api** — `/staking` adds `rewards: { amount, lastClaimAt, hasOlderRewards,
+   passesNeeded }`, computed at read time: `weekCursor + 52 weeks < currentWeek`, falling back to
+   `lock.createdAt` for never-claimed wallets (no reward row). Endpoint is already rate-limited by
+   the token-bucket durable object.
+3. **Portal** — pure UI: consume the flag from the `stakingInfo` it already fetches; the display
+   states and guided-pass stepper from Tier 1 are unchanged (the claim-button unlock cannot live
+   in the indexer).
+
+Tier 1 (client-side `weekCursorOf` read) remains valid if cross-repo coordination is the
+bottleneck — same UX, no indexer/API deploy. Both converge on identical display states.
+
+### Tier 2 — one-click backlog clearing WITHOUT touching the contract
+
+> Policy: deployed contracts are not upgraded except for security issues. Pancake's
+> `claimForUser` route (which needs an SRD upgrade) is therefore out. Both options below work
+> against the contract exactly as deployed.
+
+**2a — EIP-5792 batch from the user's own account (no new contract at all).**
+`wallet_sendCalls` executes the batch *as the user*, so the existing
+`msg.sender == user` auth check passes: batch `[claimTo(r), claimTo(r), …]` × `passesNeeded` →
+one wallet confirmation clears any backlog. The dashboard app already has the plumbing
+(`sendCalls`, `waitForBatchedTx`, `useWalletCapabilities`). Capability-gate via
+`wallet_getCapabilities` (atomic batch); non-capable EOAs fall back to the Tier-1 stepper.
+
+**2b — optional periphery helper using hooks that already exist (new standalone contract,
+zero SRD changes).** The deployed contract lets a user's *recipient* trigger claims
+(`claim(user)` allows `msg.sender == recipient[user]`). A ~50-line `ClaimHelper`:
+
+```solidity
+function claimN(address user, uint256 passes) external {
+    for (uint256 i; i < passes; i++) SRD.claim(user);     // auth: helper is user's recipient
+    WCT.transfer(user, WCT.balanceOf(address(this)));      // forward everything, same tx
+}
+```
+
+User flow: `setRecipient(helper)` once, then anyone/anything can run `claimN`; tokens always end
+at the user. With 5792 it collapses to one confirmation:
+`[setRecipient(helper), helper.claimN(user, n), setRecipient(0)]`. Deployable permissionlessly —
+no admin role, no upgrade ceremony; still deserves a focused review since users point their
+recipient at it.
+
+Recommendation between them: ship **2a** (pure FE, biggest coverage as 7702 adoption grows);
+hold 2b unless support volume from non-batching EOAs justifies a deployed helper.
+
+### Non-options considered
+
+- **FE simulates N sequential claims** (the March attempt): requires state-override simulation of
+  dependent txs — fragile, provider-specific, and unnecessary once the flag exists. Dropped.
+- **Exact pending amount in the portal**: possible (1 Multicall3 request, ~237 sub-calls — see the
+  debug skill), result immutable per (wallet, week) so cacheable weekly. Nice-to-have behind the
+  flag, not needed for the UX to work. If product wants the number, prefer the existing staking
+  API to compute/cache it weekly server-side.
+
+## Recommendation
+
+Ship **Tier 0 today**. This sprint: **Tier 1b** (indexer cursor + API flag) plus the portal UI
+unlock — the falsy-0 button bug is a straight defect to fix regardless — with **Tier 2a**
+(5792 batch) layered into the same claim flow for capable wallets. No contract changes anywhere
+in the plan; 2b stays in the back pocket if non-batching EOA volume warrants it.

--- a/evm/src/ClaimHelper.sol
+++ b/evm/src/ClaimHelper.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.25;
+
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { WalletConnectConfig } from "./WalletConnectConfig.sol";
+import { StakingRewardDistributor } from "./StakingRewardDistributor.sol";
+
+/// @title ClaimHelper
+/// @notice Standalone periphery that lets users settle a staking-reward cursor that is more than
+///         `MAX_REWARD_ITERATIONS` (52) weeks behind in a single transaction.
+/// @dev The {StakingRewardDistributor} (SRD) caps each `_claim` at 52 weeks starting from
+///      `weekCursorOf[user]`. A user who has not claimed for longer than ~1 year therefore needs to
+///      call `claim` multiple times, each call advancing their cursor by up to 52 weeks. This helper
+///      batches those passes into one call.
+///
+///      Because deployed contracts are never upgraded (except for exploits), this helper reuses the
+///      EXISTING recipient hook on the SRD instead of any new privileged entrypoint:
+///
+///      1. The user calls `SRD.setRecipient(address(claimHelper))`. This authorizes the helper to call
+///         `SRD.claim(user)` (the SRD allows `msg.sender == user || msg.sender == recipient[user]`) and
+///         routes every payout to `getRecipient(user) == address(claimHelper)`.
+///      2. The user (or anyone, see griefing note below) calls {claimN}. The helper loops `passes`
+///         times over `SRD.claim(user)`, receives the full payout, and forwards it to `user` in the
+///         same transaction.
+///      3. The user optionally calls `SRD.setRecipient(address(0))` (or restores a previous recipient)
+///         to stop routing future payouts through the helper.
+///
+///      Reentrancy: L2WCT is a plain ERC-20 with no transfer hooks, so the forward transfer cannot
+///      re-enter. `nonReentrant` is nonetheless applied to match the repo convention (see {Airdrop}).
+///
+///      Stray tokens: the helper measures its OWN WCT balance delta across the claim loop and forwards
+///      only that delta. Any pre-existing WCT balance (e.g. tokens accidentally sent to the helper) is
+///      never swept to `user`.
+///
+///      Griefing: {claimN} is permissionless, but the payout destination is always `user`, so a caller
+///      cannot redirect funds. The only effect of a third party calling it is advancing `user`'s cursor
+///      and paying gas, which is harmless.
+/// @author WalletConnect
+contract ClaimHelper is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    /// @notice The WalletConnectConfig contract, source of truth for the SRD and L2WCT addresses.
+    WalletConnectConfig public immutable config;
+
+    /// @notice Emitted when {claimN} settles rewards for a user.
+    /// @param user The user whose cursor was advanced and who received the payout.
+    /// @param caller The address that invoked {claimN}.
+    /// @param passes The number of `SRD.claim` passes executed.
+    /// @param totalClaimed The total amount of WCT forwarded to `user`.
+    event ClaimedN(address indexed user, address indexed caller, uint256 passes, uint256 totalClaimed);
+
+    /// @notice Thrown when the config address provided to the constructor is the zero address.
+    error InvalidConfig();
+
+    /// @notice Thrown when `passes` is zero.
+    error ZeroPasses();
+
+    /// @param config_ The {WalletConnectConfig} contract. The SRD and L2WCT addresses are read from it,
+    ///        so the helper always tracks the canonical deployments even if they are updated in config.
+    constructor(WalletConnectConfig config_) {
+        if (address(config_) == address(0)) revert InvalidConfig();
+        config = config_;
+    }
+
+    /// @notice Settle up to `passes * 52` weeks of pending rewards for `user` in a single transaction
+    ///         and forward the full payout to `user`.
+    /// @dev The caller does NOT need to be `user`. The helper must be `user`'s recipient on the SRD,
+    ///      i.e. `user` must have previously called `SRD.setRecipient(address(this))`. If the helper is
+    ///      not the recipient, the underlying `SRD.claim` reverts with `UnauthorizedClaimer`.
+    ///
+    ///      Each pass advances `user`'s cursor by up to 52 weeks; extra passes beyond what is needed are
+    ///      no-ops (the SRD returns 0 once the cursor reaches the current week). The payout is computed
+    ///      as the helper's WCT balance delta across the whole loop, so only freshly claimed tokens are
+    ///      forwarded and any stray pre-existing balance is left untouched.
+    /// @param user The user whose rewards are being claimed.
+    /// @param passes The number of `SRD.claim` passes to execute. Must be greater than zero.
+    /// @return totalClaimed The total amount of WCT forwarded to `user`.
+    function claimN(address user, uint256 passes) external nonReentrant returns (uint256 totalClaimed) {
+        if (passes == 0) revert ZeroPasses();
+
+        StakingRewardDistributor srd = StakingRewardDistributor(config.getStakingRewardDistributor());
+        IERC20 l2wct = IERC20(config.getL2wct());
+
+        // Measure delta, not absolute balance, so any stray pre-existing WCT is never forwarded.
+        uint256 balanceBefore = l2wct.balanceOf(address(this));
+
+        for (uint256 i = 0; i < passes; ++i) {
+            srd.claim(user);
+        }
+
+        totalClaimed = l2wct.balanceOf(address(this)) - balanceBefore;
+
+        if (totalClaimed != 0) {
+            l2wct.safeTransfer(user, totalClaimed);
+        }
+
+        emit ClaimedN(user, msg.sender, passes, totalClaimed);
+    }
+}

--- a/evm/test/integration/concrete/claim-helper/claimN/claimN.t.sol
+++ b/evm/test/integration/concrete/claim-helper/claimN/claimN.t.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.25 <0.9.0;
+
+import { ClaimHelper } from "src/ClaimHelper.sol";
+import { StakingRewardDistributor } from "src/StakingRewardDistributor.sol";
+import { StakeWeight_Integration_Shared_Test } from "../../../shared/StakeWeight.t.sol";
+
+/// @notice Integration tests for {ClaimHelper.claimN}.
+/// @dev The helper relies on the SRD recipient hook: the user calls `SRD.setRecipient(helper)`, which
+///      both authorizes the helper to claim on their behalf and routes payouts to the helper, which
+///      then forwards them to the user.
+contract ClaimN_ClaimHelper_Integration_Concrete_Test is StakeWeight_Integration_Shared_Test {
+    /// @dev Mirror of the event defined in {ClaimHelper}.
+    event ClaimedN(address indexed user, address indexed caller, uint256 passes, uint256 totalClaimed);
+
+    ClaimHelper internal claimHelper;
+
+    /// @dev Per-week reward injected for the multi-pass scenario. The locker is the sole staker, so
+    ///      they receive the full weekly amount each week.
+    uint256 internal constant WEEKLY_REWARD = 1000 ether;
+
+    function setUp() public override {
+        super.setUp();
+        // setRecipient and token transfers require transfer restrictions to be disabled.
+        disableTransferRestrictions();
+        claimHelper = new ClaimHelper(walletConnectConfig);
+        // Align the SRD week cursor to the current week, mirroring the existing SRD claim tests.
+        vm.warp(_timestampToFloorWeek(block.timestamp + 1 weeks));
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Injects `WEEKLY_REWARD` into each of the next `numWeeks` weeks starting from the current week.
+    function _injectWeeklyRewards(uint256 numWeeks) internal {
+        uint256 currentWeek = _timestampToFloorWeek(block.timestamp);
+        uint256 total = WEEKLY_REWARD * numWeeks;
+
+        deal(address(l2wct), users.admin, total);
+        vm.startPrank(users.admin);
+        l2wct.approve(address(stakingRewardDistributor), total);
+        for (uint256 i = 0; i < numWeeks; i++) {
+            stakingRewardDistributor.injectReward({ timestamp: currentWeek + (i * 1 weeks), amount: WEEKLY_REWARD });
+        }
+        vm.stopPrank();
+    }
+
+    /// @dev Creates a permanent lock so the user's weight (and thus weekly reward share) stays constant.
+    function _createPermanentLock(address user, uint256 amount) internal {
+        deal(address(l2wct), user, amount);
+        vm.startPrank(user);
+        l2wct.approve(address(stakeWeight), amount);
+        stakeWeight.createPermanentLock(amount, 52 weeks);
+        vm.stopPrank();
+    }
+
+    modifier asRecipient(address user) {
+        vm.prank(user);
+        stakingRewardDistributor.setRecipient(address(claimHelper));
+        _;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     REVERTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_RevertWhen_PassesIsZero() external {
+        vm.expectRevert(ClaimHelper.ZeroPasses.selector);
+        claimHelper.claimN(users.alice, 0);
+    }
+
+    modifier whenPassesIsGreaterThanZero() {
+        _;
+    }
+
+    function test_RevertWhen_HelperIsNotRecipient() external whenPassesIsGreaterThanZero {
+        // Alice has a lock and pending rewards but never set the helper as her recipient.
+        _createPermanentLock(users.alice, 1000 ether);
+        _injectWeeklyRewards(1);
+        _mineBlocks(defaults.ONE_WEEK_IN_BLOCKS());
+
+        // SRD.claim reverts because msg.sender (the helper) is neither the user nor the user's recipient.
+        vm.expectRevert(StakingRewardDistributor.UnauthorizedClaimer.selector);
+        claimHelper.claimN(users.alice, 1);
+    }
+
+    modifier whenHelperIsRecipient() {
+        _;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  MULTI-PASS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_ClaimN_StaleCursorMoreThan52WeeksBehind()
+        external
+        whenPassesIsGreaterThanZero
+        whenHelperIsRecipient
+        asRecipient(users.alice)
+    {
+        uint256 lockAmount = 1000 ether;
+        _createPermanentLock(users.alice, lockAmount);
+
+        // Inject rewards for 104 weeks (2x the 52-week per-call cap), then advance past all of them so
+        // the entire window is claimable. Alice never claims, so her cursor is stranded >52 weeks back.
+        uint256 numWeeks = 104;
+        _injectWeeklyRewards(numWeeks);
+        _mineBlocks(defaults.ONE_WEEK_IN_BLOCKS() * (numWeeks + 1));
+
+        uint256 expectedTotal = WEEKLY_REWARD * numWeeks;
+
+        uint256 aliceBefore = l2wct.balanceOf(users.alice);
+
+        // Two passes are required: one call only settles up to 52 weeks.
+        vm.expectEmit(true, true, true, true);
+        emit ClaimedN(users.alice, address(this), 2, expectedTotal);
+        uint256 totalClaimed = claimHelper.claimN(users.alice, 2);
+
+        assertEq(totalClaimed, expectedTotal, "should claim the full 104 weeks across 2 passes");
+        assertEq(
+            l2wct.balanceOf(users.alice) - aliceBefore, expectedTotal, "user balance should increase by full pending"
+        );
+        assertEq(l2wct.balanceOf(address(claimHelper)), 0, "helper should retain nothing");
+    }
+
+    function test_ClaimN_StaleCursor_OnePassIsNotEnough()
+        external
+        whenPassesIsGreaterThanZero
+        whenHelperIsRecipient
+        asRecipient(users.alice)
+    {
+        _createPermanentLock(users.alice, 1000 ether);
+
+        uint256 numWeeks = 104;
+        _injectWeeklyRewards(numWeeks);
+        _mineBlocks(defaults.ONE_WEEK_IN_BLOCKS() * (numWeeks + 1));
+
+        // A single pass settles at most 52 weeks, leaving the rest pending.
+        uint256 onePass = claimHelper.claimN(users.alice, 1);
+        assertEq(onePass, WEEKLY_REWARD * 52, "single pass should settle exactly 52 weeks");
+
+        // A second invocation settles the remaining 52 weeks.
+        uint256 secondPass = claimHelper.claimN(users.alice, 1);
+        assertEq(secondPass, WEEKLY_REWARD * 52, "second pass should settle the remaining 52 weeks");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                              SINGLE-PASS EQUIVALENCE
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_ClaimN_SinglePassMatchesDirectClaim() external whenPassesIsGreaterThanZero whenHelperIsRecipient {
+        // Two identical users: alice claims directly, bob claims via the helper with a single pass.
+        _createPermanentLock(users.alice, 1000 ether);
+        _createPermanentLock(users.bob, 1000 ether);
+        _injectWeeklyRewards(1);
+        _mineBlocks(defaults.ONE_WEEK_IN_BLOCKS());
+
+        // Bob routes through the helper.
+        vm.prank(users.bob);
+        stakingRewardDistributor.setRecipient(address(claimHelper));
+
+        vm.prank(users.alice);
+        uint256 aliceDirect = stakingRewardDistributor.claim(users.alice);
+        uint256 bobViaHelper = claimHelper.claimN(users.bob, 1);
+
+        assertEq(bobViaHelper, aliceDirect, "single-pass claimN should equal a direct claim");
+        assertEq(l2wct.balanceOf(users.bob), bobViaHelper, "bob should receive his rewards");
+        assertEq(l2wct.balanceOf(address(claimHelper)), 0, "helper should retain nothing");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                DELTA ISOLATION
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_ClaimN_DoesNotForwardStrayBalance()
+        external
+        whenPassesIsGreaterThanZero
+        whenHelperIsRecipient
+        asRecipient(users.alice)
+    {
+        _createPermanentLock(users.alice, 1000 ether);
+        _injectWeeklyRewards(1);
+        _mineBlocks(defaults.ONE_WEEK_IN_BLOCKS());
+
+        // Pre-fund the helper with stray WCT that must NOT be forwarded to alice.
+        uint256 stray = 777 ether;
+        deal(address(l2wct), address(claimHelper), stray);
+
+        uint256 aliceBefore = l2wct.balanceOf(users.alice);
+        uint256 totalClaimed = claimHelper.claimN(users.alice, 1);
+
+        assertEq(totalClaimed, WEEKLY_REWARD, "should claim only one week of rewards");
+        assertEq(l2wct.balanceOf(users.alice) - aliceBefore, WEEKLY_REWARD, "stray balance must not be forwarded");
+        assertEq(l2wct.balanceOf(address(claimHelper)), stray, "stray balance must remain in the helper");
+    }
+}

--- a/evm/test/integration/concrete/claim-helper/claimN/claimN.tree
+++ b/evm/test/integration/concrete/claim-helper/claimN/claimN.tree
@@ -1,0 +1,16 @@
+claimN.t.sol
+├── when passes is zero
+│   └── it should revert with ZeroPasses
+└── when passes is greater than zero
+    ├── when the helper is not the user's recipient
+    │   └── it should revert with UnauthorizedClaimer
+    └── when the helper is the user's recipient
+        ├── when the user's cursor is more than 52 weeks behind
+        │   └── it should claim across multiple passes
+        │       ├── it should forward the full pending amount to the user
+        │       ├── it should leave the helper balance at zero
+        │       └── it should emit ClaimedN with the total claimed
+        ├── when a single pass settles the user's pending rewards
+        │   └── it should match a direct claim
+        └── when the helper holds stray WCT
+            └── it should forward only the claimed delta and not the stray balance


### PR DESCRIPTION
Exploration of a claim periphery; closed in favor of frontend batching.