### PR TITLE
fix(deploy): verify airdrop reserve allowance so it can't ship unclaimable

### DIFF
--- a/evm/script/deploy/OptimismDeploy.s.sol
+++ b/evm/script/deploy/OptimismDeploy.s.sol
@@ -438,6 +438,12 @@ contract OptimismDeploy is BaseScript {
         if (deps.airdrop.reserveAddress() != params.treasury) {
             revert("Airdrop reserveAddress is not Treasury");
         }
+        // claimTokens pulls via transferFrom(reserveAddress, ...), so the reserve MUST have approved the
+        // Airdrop to spend L2WCT — without it the airdrop is deployed but unclaimable. Verify the allowance
+        // so a missing treasury approval fails verification instead of shipping a dead airdrop.
+        if (deps.l2wct.allowance(params.treasury, address(deps.airdrop)) == 0) {
+            revert("Airdrop reserve has not approved the Airdrop (would be unclaimable)");
+        }
         if (!deps.airdrop.hasRole(deps.airdrop.DEFAULT_ADMIN_ROLE(), params.admin)) {
             revert("Airdrop default admin is not Admin MultiSig");
         }


### PR DESCRIPTION
`Airdrop.claimTokens` pulls tokens via `transferFrom(reserveAddress, ...)`, but `verifyDeployments` never checked the reserve's allowance to the Airdrop. A deployment with an unfunded/unapproved treasury passed verification yet was unclaimable. Assert `allowance(treasury, airdrop) > 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)